### PR TITLE
feat: Refactor LGTM to use external MinIO & configure KPS

### DIFF
--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -102,6 +102,16 @@ spec:
                 hide: false
               nodeGraph:
                 enabled: true
+          - name: Mimir
+            type: prometheus
+            uid: mimir # Unique UID for this datasource
+            access: proxy
+            url: http://mimir-nginx.observability.svc.cluster.local:80/prometheus # Mimir query endpoint via gateway
+            isDefault: false
+            jsonData:
+              httpHeaderName1: "X-Scope-OrgID"
+              httpHeaderValue1: "anonymous" # Default tenant ID
+            # editable: true
     dashboardProviders:
       dashboardproviders.yaml:
         apiVersion: 1

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -60,6 +60,13 @@ spec:
           global:
             resolveTimeout: 5m
         externalUrl: https://alertmanager.samcloud.online
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: "1"
+            memory: 512Mi
         storage:
           volumeClaimTemplate:
             spec:
@@ -161,6 +168,19 @@ spec:
         probeSelectorNilUsesHelmValues: false
         scrapeConfigSelectorNilUsesHelmValues: false
         enableAdminAPI: true
+        resources: # Added for Prometheus
+          requests:
+            cpu: 500m
+            memory: 2Gi
+          limits:
+            cpu: "2"
+            memory: 4Gi
+        remoteWrite: # Added for Mimir integration
+          - url: "http://mimir-nginx.observability.svc.cluster.local:80/api/v1/push"
+            queueConfig:
+              maxSamplesPerSend: 1000
+              maxShards: 20
+              capacity: 2500
         walCompression: true
         retention: 14d
         retentionSize: 30GB

--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -45,20 +45,27 @@ spec:
       commonConfig:
         replication_factor: 1
       compactor:
-        working_directory: /var/loki/compactor/retention
-        delete_request_store: filesystem
+        working_directory: /var/loki/compactor/retention # This might also need to be an S3 path eventually, but let's start here.
+        delete_request_store: s3
         retention_enabled: true
       ingester:
         chunk_encoding: snappy
       limits_config:
         retention_period: 14d
       storage:
-        type: filesystem
+        type: s3
+        s3:
+          endpoint: http://192.168.8.161:9000
+          bucket_name: loki-data-7f3d9a # Using singular form
+          access_key_id: dummy # Will be overridden by env var
+          secret_access_key: dummy # Will be overridden by env var
+          s3forcepathstyle: true
+          insecure: true
       schemaConfig:
         configs:
           - from: "2024-04-01" # quote
             store: tsdb
-            object_store: filesystem
+            object_store: s3 # Changed from filesystem
             schema: v13
             index:
               prefix: loki_index_
@@ -75,6 +82,17 @@ spec:
           rule_path: /rules/fake
     singleBinary:
       replicas: 1
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials-secret
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials-secret
+              key: AWS_SECRET_ACCESS_KEY
       resources:
         requests:
           cpu: 200m
@@ -82,10 +100,10 @@ spec:
         limits:
           cpu: "2"
           memory: 2Gi
-      persistence:
-        enabled: true
-        storageClass: openebs-hostpath
-        size: 50Gi
+      # persistence: # Removed filesystem persistence
+      #   enabled: true
+      #   storageClass: openebs-hostpath
+      #   size: 50Gi
     gateway:
       replicas: 0
     backend:

--- a/kubernetes/apps/observability/mimir/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mimir/app/helmrelease.yaml
@@ -29,7 +29,17 @@ spec:
     global:
       # -- Common environment variables to add to all pods directly managed by this chart.
       # scope: admin-api, alertmanager, compactor, continuous-test, distributor, gateway, graphite-proxy, ingester, memcached, nginx, overrides-exporter, querier, query-frontend, query-scheduler, ruler, store-gateway, smoke-test, tokengen
-      extraEnv: []
+      extraEnv:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials-secret
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials-secret
+              key: AWS_SECRET_ACCESS_KEY
 
       # -- Common source of environment injections to add to all pods directly managed by this chart.
       # scope: admin-api, alertmanager, compactor, continuous-test, distributor, gateway, graphite-proxy, ingester, memcached, nginx, overrides-exporter, querier, query-frontend, query-scheduler, ruler, store-gateway, smoke-test, tokengen
@@ -37,11 +47,7 @@ spec:
       # extraEnvFrom:
       #   - secretRef:
       #       name: mysecret
-      extraEnvFrom:
-        - configMapRef:
-            name: mimir-blocks-bucket
-        - secretRef:
-            name: mimir-bucket
+      extraEnvFrom: [] # Removed old references to mimir-blocks-bucket and mimir-bucket
       # -- Common volumes to add to all pods directly managed by this chart.
       # scope: admin-api, alertmanager, compactor, continuous-test, distributor, gateway, graphite-proxy, ingester, memcached, nginx, overrides-exporter, querier, query-frontend, query-scheduler, ruler, store-gateway, smoke-test, tokengen
       extraVolumes: []
@@ -81,21 +87,22 @@ spec:
           storage:
             backend: s3
             s3:
-              endpoint: "$${BUCKET_HOST}:$${BUCKET_PORT}"
-              access_key_id: "$${AWS_ACCESS_KEY_ID}"
-              secret_access_key: "$${AWS_SECRET_ACCESS_KEY}"
-              insecure: false
+              endpoint: "http://192.168.8.161:9000" # Direct endpoint
+              access_key_id: "" # Will be picked from env
+              secret_access_key: "" # Will be picked from env
+              insecure: true # For HTTP endpoint
+              s3forcepathstyle: true # For MinIO compatibility
               http:
-                insecure_skip_verify: false
+                insecure_skip_verify: true # For HTTP endpoint
         blocks_storage:
           s3:
-            bucket_name: mimir-blocks
+            bucket_name: mimir-blocks-9k4l2m
         alertmanager_storage:
           s3:
-            bucket_name: mimir-alertmanager
+            bucket_name: mimir-alertmanager-9k4l2m
         ruler_storage:
           s3:
-            bucket_name: mimir-ruler
+            bucket_name: mimir-ruler-9k4l2m
         limits:
           # Delete from storage metrics data older than 90 days.
           compactor_blocks_retention_period: 90d

--- a/kubernetes/apps/observability/tempo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/tempo/app/helmrelease.yaml
@@ -32,6 +32,17 @@ spec:
   values:
     replicas: 2
     tempo:
+      extraEnv:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials-secret
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials-secret
+              key: AWS_SECRET_ACCESS_KEY
       reportingEnabled: false
       metricsGenerator:
         enabled: true
@@ -89,7 +100,12 @@ spec:
         trace:
           backend: s3
           s3:
-            insecure: false                                 # optional. enable if endpoint is http
+            bucket: tempo-traces-8g2h1j
+            endpoint: http://192.168.8.161:9000
+            access_key: "" # Overridden by env var
+            secret_key: "" # Overridden by env var
+            insecure: true # For HTTP endpoint
+            s3ForcePathStyle: true
     persistence:
       enabled: false
     tempoQuery:
@@ -107,20 +123,4 @@ spec:
               - *host
     serviceMonitor:
       enabled: true
-  valuesFrom:
-    - targetPath: tempo.storage.trace.s3.bucket
-      kind: ConfigMap
-      name: tempo-bucket
-      valuesKey: BUCKET_NAME
-    - targetPath: tempo.storage.trace.s3.endpoint
-      kind: ConfigMap
-      name: tempo-bucket
-      valuesKey: BUCKET_HOST
-    - targetPath: tempo.storage.trace.s3.access_key
-      kind: Secret
-      name: tempo-bucket
-      valuesKey: AWS_ACCESS_KEY_ID
-    - targetPath: tempo.storage.trace.s3.secret_key
-      kind: Secret
-      name: tempo-bucket
-      valuesKey: AWS_SECRET_ACCESS_KEY
+# valuesFrom block removed


### PR DESCRIPTION
This commit finalizes the initial production readiness configuration for the LGTM stack (Loki, Grafana, Tempo, Mimir) and Kube-Prometheus-Stack (KPS).

Key changes:

1.  **External MinIO Integration:**
    *   I refactored Loki, Tempo, and Mimir HelmReleases to use an external
        MinIO S3 backend (endpoint: `http://192.168.8.161:9000`).
    *   I updated S3 configurations (bucket names, endpoint, insecure settings
        for HTTP, s3ForcePathStyle).
    *   I standardized S3 credential sourcing from a common Kubernetes secret
        `minio-credentials-secret` (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
        for all three components.
    *   I generated bucket names:
        *   Loki: `loki-data-7f3d9a`
        *   Tempo: `tempo-traces-8g2h1j`
        *   Mimir: `mimir-blocks-9k4l2m`, `mimir-alertmanager-9k4l2m`, `mimir-ruler-9k4l2m`

2.  **Kube-Prometheus-Stack (KPS) Configuration:**
    *   I added resource requests and limits for Prometheus and Alertmanager.
    *   I configured Prometheus to `remote_write` metrics to Mimir at
        `http://mimir-nginx.observability.svc.cluster.local:80/api/v1/push`,
        including queue configuration for reliability.

3.  **Grafana Mimir Datasource:**
    *   I added a Mimir datasource to Grafana, pointing to
        `http://mimir-nginx.observability.svc.cluster.local:80/prometheus`
        with `X-Scope-OrgID: anonymous`. This allows Grafana to query
        long-term metrics stored in Mimir.

This completes the setup of the core observability components with externalized S3 storage and integrated data flow for logs, traces, and metrics.